### PR TITLE
Reduced Splash Volume of Thrown Reagant Containers

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -86,7 +86,7 @@
 		return
 
 	if(ismob(target) && target.reagents)
-		reagents.total_volume *= rand(5,10) * 0.1 //Not all of it makes contact with the target
+		reagents.total_volume *= rand(1,2) * 0.1 //Not all of it makes contact with the target
 		var/mob/M = target
 		var/R
 		target.visible_message("<span class='danger'>[M] has been splashed with something!</span>", \


### PR DESCRIPTION
Splashed volume over a thrown reagant container changed from 50-100% to 10-20%.

I hope this doesn't need explaining. Still retains some purpose if you want to just splash a small volume on someone or use a 100 volume container to splash a more significant volume (i.e. enough morphine to knock someone out for a 30 seconds). 