### PR TITLE
Fixes Changeling Team Department Objectives

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -89,7 +89,8 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 			possible_team_objectives += T
 
 	if(possible_team_objectives.len && prob(20*changelings.len))
-		changeling_team_objective_type = pick(possible_team_objectives)
+		if(changeling_team_objective_type = null)
+			changeling_team_objective_type = pick(possible_team_objectives)
 
 	for(var/datum/mind/changeling in changelings)
 		log_game("[changeling.key] (ckey) has been selected as a changeling")
@@ -186,7 +187,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 
 /datum/game_mode/changeling/forge_changeling_objectives(datum/mind/changeling)
 	if(changeling_team_objective_type)
-		var/datum/objective/changeling_team_objective/team_objective = new changeling_team_objective_type
+		var/datum/objective/changeling_team_objective/team_objective = changeling_team_objective_type
 		team_objective.owner = changeling
 		changeling.objectives += team_objective
 


### PR DESCRIPTION
Maybe, remember I don't actually know how to code.

Currently Teamling will "reroll" the team objective for each ling, meaning that you can get a "team" where each member has to get the entire team to impersonate a different department, which completely destroys the concept of them being a team. (e.g. Mr. Zeta has to get all the lings to impersonate the science dept. members while Mrs. Gamma has to get all the lings to impersonate the medical department).